### PR TITLE
Add tree-height and AOI-radius filters with pinned forest plot

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,89 @@
   .section { padding: 8px 16px 12px; border-top:1px solid #1e2230; }
   .section-label { font-size:11px; text-transform:uppercase; color:#5a6070; letter-spacing:.08em; margin-bottom:6px; }
 
+  /* ---- Filters drawer ---- */
+  .filters-header {
+    display: flex; justify-content: space-between; align-items: center;
+    cursor: pointer; user-select: none;
+  }
+  .filters-header:hover { color: #8a90a0; }
+  #filters-caret { transition: transform .2s; display: inline-block; font-size: 9px; }
+  #filters-section.collapsed #filters-caret { transform: rotate(-90deg); }
+  #filters-body {
+    max-height: 400px; opacity: 1; overflow: hidden;
+    transition: max-height .3s ease, opacity .2s ease;
+    padding-top: 4px;
+  }
+  #filters-section.collapsed #filters-body { max-height: 0; opacity: 0; padding-top: 0; }
+
+  .filter-row { margin-bottom: 12px; }
+  .filter-row:last-child { margin-bottom: 0; }
+  .filter-row-head {
+    display: flex; justify-content: space-between; align-items: baseline;
+    font-size: 10px; color: #8a90a0; margin-bottom: 6px;
+    text-transform: uppercase; letter-spacing: .05em;
+  }
+  .filter-readout {
+    font-family: 'JetBrains Mono', monospace; font-size: 11px;
+    color: #e4e8f0; text-transform: none; letter-spacing: 0;
+  }
+
+  /* Native range slider */
+  .filter-slider {
+    -webkit-appearance: none; appearance: none;
+    width: 100%; height: 4px; background: #1e2230;
+    border-radius: 2px; outline: none; margin: 8px 0;
+    cursor: pointer;
+  }
+  .filter-slider:disabled { opacity: 0.4; cursor: not-allowed; }
+  .filter-slider::-webkit-slider-runnable-track {
+    height: 4px; background: #1e2230; border-radius: 2px;
+  }
+  .filter-slider::-moz-range-track {
+    height: 4px; background: #1e2230; border-radius: 2px; border: none;
+  }
+  .filter-slider::-webkit-slider-thumb {
+    -webkit-appearance: none; appearance: none;
+    width: 16px; height: 16px; border-radius: 50%;
+    background: #e4e8f0; border: 2px solid #3d8b40;
+    cursor: pointer; margin-top: -6px;
+    transition: transform .1s;
+  }
+  .filter-slider::-moz-range-thumb {
+    width: 14px; height: 14px; border-radius: 50%;
+    background: #e4e8f0; border: 2px solid #3d8b40;
+    cursor: pointer;
+  }
+  .filter-slider:active::-webkit-slider-thumb { transform: scale(1.15); }
+  .filter-slider:focus { outline: none; }
+  .filter-slider:focus::-webkit-slider-thumb { box-shadow: 0 0 0 4px rgba(61,139,64,.25); }
+
+  /* Origin toggle */
+  .origin-toggle {
+    display: flex; background: #0c0e13; border: 1px solid #2a2e3a;
+    border-radius: 4px; overflow: hidden;
+  }
+  .origin-toggle button {
+    flex: 1; background: none; border: none; color: #5a6070; cursor: pointer;
+    font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600;
+    padding: 6px 8px; transition: background .15s, color .15s;
+  }
+  .origin-toggle button.active { background: #1e2230; color: #e4e8f0; }
+  .origin-toggle button:hover:not(.active) { color: #8a90a0; }
+  .origin-info {
+    font-size: 10px; color: #5a6070; margin-top: 4px; min-height: 12px;
+    font-family: 'JetBrains Mono', monospace;
+  }
+  .origin-info.error { color: #ff8800; }
+
+  .filters-reset {
+    background: #1e2230; border: 1px solid #2a2e3a; color: #8a90a0;
+    font-family: 'JetBrains Mono', monospace; font-size: 11px;
+    padding: 6px 10px; border-radius: 4px; cursor: pointer;
+    width: 100%; transition: background .15s, color .15s;
+  }
+  .filters-reset:hover { background: #2a2e3a; color: #e4e8f0; }
+
   /* ---- Map ---- */
   #map-wrap { flex:1; position:relative; }
   #map { width:100%; height:100%; }
@@ -399,11 +482,51 @@
     </div>
     <button id="collapse-btn" aria-label="Collapse panel">&#9650;</button>
   </div>
+
+  <div class="section" id="forest-section">
+    <div class="section-label">Forest Profile</div>
+    <svg id="forest-viz" preserveAspectRatio="xMidYMax meet"></svg>
+  </div>
+
   <div id="sidebar-body">
 
-    <div class="section" id="forest-section">
-      <div class="section-label">Forest Profile</div>
-      <svg id="forest-viz" preserveAspectRatio="xMidYMax meet"></svg>
+    <div class="section" id="filters-section">
+      <div class="section-label filters-header" onclick="toggleFilters()">
+        <span>Filters</span>
+        <span id="filters-caret">&#9660;</span>
+      </div>
+      <div id="filters-body">
+
+        <div class="filter-row">
+          <div class="filter-row-head">
+            <span>Min tree height</span>
+            <span class="filter-readout" id="height-readout">— m</span>
+          </div>
+          <input type="range" id="height-slider" class="filter-slider" min="0" max="100" value="0" step="1" disabled />
+        </div>
+
+        <div class="filter-row">
+          <div class="filter-row-head">
+            <span>AOI radius</span>
+            <span class="filter-readout" id="dist-readout">— m</span>
+          </div>
+          <input type="range" id="dist-slider" class="filter-slider" min="25" max="500" value="500" step="1" disabled />
+        </div>
+
+        <div class="filter-row">
+          <div class="filter-row-head"><span>Distance from</span></div>
+          <div id="origin-toggle" class="origin-toggle">
+            <button id="origin-click" class="active" onclick="setDistanceOrigin('click')">Click center</button>
+            <button id="origin-gps" onclick="setDistanceOrigin('gps')">My GPS</button>
+          </div>
+          <div id="origin-info" class="origin-info"></div>
+        </div>
+
+        <div class="filter-row">
+          <button class="filters-reset" onclick="resetFilters()">Reset filters</button>
+        </div>
+
+      </div>
     </div>
 
     <div class="section" id="stats-section">
@@ -544,14 +667,13 @@ function setUnits(unit) {
   refreshUnits();
 }
 function refreshUnits() {
-  if (!window._lastData) return;
+  if (!window._lastData) { updateReadouts(); return; }
   const data = window._lastData;
   document.getElementById('stat-max').textContent = fmtH(data.stats.max_height);
   document.getElementById('stat-mean').textContent = fmtH(data.stats.mean_height);
-  data.trees.forEach(t => {
-    if (t._marker) t._marker.setTooltipContent(`#${t.rank} — ${fmtH(t.height_m)} (${t.tier})`);
-  });
-  renderForest(data.trees, window._lastLat, window._lastLng);
+  // Re-render markers + forest through the filter pipeline so tooltips and
+  // silhouettes pick up the new units. Filter state is preserved.
+  applyFilters();
   if (gtSelectedTree) {
     document.getElementById('gt-title').textContent = `#${gtSelectedTree.rank} — ${fmtH(gtSelectedTree.height_m)}`;
     updateNavigation();
@@ -569,6 +691,185 @@ function togglePanel() {
   // Invalidate map size after transition
   setTimeout(() => map.invalidateSize(), 320);
 }
+
+// ---- Filters drawer ----
+const AOI_MIN_RADIUS = 25;  // metres; hard floor for AOI slider
+const filterState = {
+  heightMin: 0,
+  heightMax: 100,
+  aoiRadius: 500,
+  aoiMax: 500,
+  origin: 'click',   // 'click' | 'gps'
+};
+
+function toggleFilters() {
+  document.getElementById('filters-section').classList.toggle('collapsed');
+}
+
+function originLatLon() {
+  if (filterState.origin === 'gps' && gtUserPos) return [gtUserPos.lat, gtUserPos.lon];
+  if (window._lastLat != null) return [window._lastLat, window._lastLng];
+  return [null, null];
+}
+
+function distanceFor(tree) {
+  const [oLat, oLon] = originLatLon();
+  if (oLat == null) return 0;
+  return haversineMeters(oLat, oLon, tree.lat, tree.lon);
+}
+
+function getFilteredTrees() {
+  const trees = (window._lastData && window._lastData.trees) || [];
+  const { heightMin, aoiRadius } = filterState;
+  return trees.filter(t => {
+    if (t.height_m < heightMin) return false;
+    if (distanceFor(t) > aoiRadius) return false;
+    return true;
+  });
+}
+
+function updateReadouts() {
+  document.getElementById('height-readout').textContent =
+    window._lastData ? `≥ ${fmtH(filterState.heightMin)}` : '— m';
+  document.getElementById('dist-readout').textContent =
+    window._lastData ? `≤ ${filterState.aoiRadius} m` : '— m';
+}
+
+function renderMarkers(trees) {
+  markers.forEach(m => map.removeLayer(m));
+  markers = [];
+  trees.forEach(t => {
+    const m = L.circleMarker([t.lat, t.lon], {
+      radius: Math.max(4, Math.min(10, t.height_m / 10)),
+      color: t.colour,
+      weight: 1.5,
+      fillColor: t.colour,
+      fillOpacity: 0.5,
+    }).addTo(map);
+    m.bindTooltip(`#${t.rank} — ${fmtH(t.height_m)} (${t.tier})`, { className: 'tree-tip' });
+    m.on('click', () => highlightTree(t));
+    t._marker = m;
+    markers.push(m);
+  });
+}
+
+let _applyFiltersRaf = 0;
+function applyFilters() {
+  if (!window._lastData) return;
+  if (_applyFiltersRaf) return;
+  _applyFiltersRaf = requestAnimationFrame(() => {
+    _applyFiltersRaf = 0;
+    const filtered = getFilteredTrees();
+    renderMarkers(filtered);
+    renderForest(filtered, window._lastLat, window._lastLng);
+    updateReadouts();
+  });
+}
+
+function recomputeDistanceBounds() {
+  const trees = (window._lastData && window._lastData.trees) || [];
+  const slider = document.getElementById('dist-slider');
+  if (!trees.length) {
+    slider.disabled = true;
+    return;
+  }
+  const ds = trees.map(distanceFor);
+  const dMax = Math.max(AOI_MIN_RADIUS, Math.ceil(Math.max(...ds)));
+  filterState.aoiMax = dMax;
+  filterState.aoiRadius = dMax;
+  slider.min = AOI_MIN_RADIUS;
+  slider.max = dMax;
+  slider.step = Math.max(1, Math.floor((dMax - AOI_MIN_RADIUS) / 200));
+  slider.value = dMax;
+  slider.disabled = false;
+}
+
+function recomputeBoundsFromData() {
+  const trees = (window._lastData && window._lastData.trees) || [];
+  const hSlider = document.getElementById('height-slider');
+  if (!trees.length) {
+    hSlider.disabled = true;
+    filterState.heightMin = 0;
+    filterState.heightMax = 100;
+    recomputeDistanceBounds();
+    return;
+  }
+  const hMax = Math.ceil(Math.max(...trees.map(t => t.height_m)));
+  filterState.heightMin = 0;
+  filterState.heightMax = hMax;
+  hSlider.min = 0;
+  hSlider.max = hMax;
+  hSlider.step = Math.max(1, Math.floor(hMax / 200));
+  hSlider.value = 0;
+  hSlider.disabled = false;
+
+  recomputeDistanceBounds();
+}
+
+function resetFilters() {
+  filterState.heightMin = 0;
+  filterState.aoiRadius = filterState.aoiMax;
+  document.getElementById('height-slider').value = 0;
+  document.getElementById('dist-slider').value = filterState.aoiMax;
+  applyFilters();
+}
+
+function setDistanceOrigin(which) {
+  if (which === 'gps') {
+    if (!gtUserPos) {
+      requestGpsForFilter();
+      return;  // wait for fix; toggle flips on success
+    }
+  }
+  filterState.origin = which;
+  document.getElementById('origin-click').classList.toggle('active', which === 'click');
+  document.getElementById('origin-gps').classList.toggle('active', which === 'gps');
+  recomputeDistanceBounds();
+  applyFilters();
+}
+
+function requestGpsForFilter() {
+  const info = document.getElementById('origin-info');
+  info.classList.remove('error');
+  if (!window.isSecureContext) {
+    info.textContent = 'GPS requires HTTPS';
+    info.classList.add('error');
+    return;
+  }
+  if (!navigator.geolocation) {
+    info.textContent = 'Geolocation unsupported';
+    info.classList.add('error');
+    return;
+  }
+  info.textContent = 'Acquiring GPS…';
+  navigator.geolocation.getCurrentPosition(
+    (pos) => {
+      gtUserPos = { lat: pos.coords.latitude, lon: pos.coords.longitude };
+      info.textContent = `GPS fix: ±${pos.coords.accuracy.toFixed(0)} m`;
+      setDistanceOrigin('gps');
+    },
+    (err) => {
+      info.classList.add('error');
+      info.textContent = 'GPS error: ' + (err.message || err.code);
+    },
+    { enableHighAccuracy: true, timeout: 15000 }
+  );
+}
+
+// Wire slider input events
+document.addEventListener('DOMContentLoaded', () => {
+  const hSlider = document.getElementById('height-slider');
+  const dSlider = document.getElementById('dist-slider');
+  hSlider.addEventListener('input', () => {
+    filterState.heightMin = +hSlider.value;
+    applyFilters();
+  });
+  dSlider.addEventListener('input', () => {
+    filterState.aoiRadius = +dSlider.value;
+    applyFilters();
+  });
+  updateReadouts();
+});
 
 // ---- Map setup ----
 window._map = L.map('map', {
@@ -714,23 +1015,11 @@ map.on('click', async (e) => {
       ).addTo(map);
     }
 
-    // Markers
-    data.trees.forEach(t => {
-      const m = L.circleMarker([t.lat, t.lon], {
-        radius: Math.max(4, Math.min(10, t.height_m / 10)),
-        color: t.colour,
-        weight: 1.5,
-        fillColor: t.colour,
-        fillOpacity: 0.5,
-      }).addTo(map);
-      m.bindTooltip(`#${t.rank} — ${fmtH(t.height_m)} (${t.tier})`, { className: 'tree-tip' });
-      m.on('click', () => highlightTree(t));
-      t._marker = m;
-      markers.push(m);
-    });
-
-    // Forest profile visualization
-    renderForest(data.trees, lat, lng);
+    // Recompute filter bounds from this analysis, then render markers + forest
+    // through the filter pipeline. Stats above are full-AOI and remain unchanged
+    // by slider drags.
+    recomputeBoundsFromData();
+    applyFilters();
 
   } catch (err) {
     alert('Analysis failed: ' + err.message);
@@ -771,7 +1060,22 @@ function renderForest(trees, centerLat, centerLon) {
   svg.innerHTML = '';
 
   const vizTrees = trees.slice(0, 200);
-  if (!vizTrees.length) return;
+  if (!vizTrees.length) {
+    const rect = svg.getBoundingClientRect();
+    const W = rect.width || 300;
+    const H = rect.height || 160;
+    svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+    const msg = document.createElementNS(SVG_NS, 'text');
+    msg.setAttribute('x', W / 2);
+    msg.setAttribute('y', H / 2);
+    msg.setAttribute('text-anchor', 'middle');
+    msg.setAttribute('fill', '#5a6070');
+    msg.setAttribute('font-family', "'JetBrains Mono', monospace");
+    msg.setAttribute('font-size', '11');
+    msg.textContent = window._lastData ? 'No trees match current filters' : '';
+    svg.appendChild(msg);
+    return;
+  }
 
   // Inject silhouette symbols into defs
   const defs = document.createElementNS(SVG_NS, 'defs');


### PR DESCRIPTION
- Pull #forest-section out of #sidebar-body so the tree plot stays
  visible even when the sidebar is collapsed.
- Add a new collapsible filters drawer (#filters-section) with:
    * height min slider (0 m -> data max)
    * AOI radius slider (25 m floor -> data max distance)
    * Click center / GPS origin toggle for the AOI radius
    * reset button
- Sliders drive a single applyFilters() pipeline (rAF-batched) that
  refreshes Leaflet markers and the forest silhouette plot. Stats stay
  pinned to the full /api/analyze result.
- renderForest renders a centered "No trees match current filters"
  message when the active filter empties the result.
- refreshUnits() now replays through applyFilters() so tooltips,
  silhouettes, and the height readout all reformat on m/ft toggle.

No backend changes. AR-mode purge is a no-op: a repo-wide search
confirmed there are no AR / ARKit / augmented-reality references to
remove.