### PR TITLE
chore: rename github URLs tommyroar → robogeosociety

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,6 @@
 name: Claude PR Assistant
 
-# Canonical @claude responder — source of truth: tommyroar/.github.
+# Canonical @claude responder — source of truth: robogeosociety/.github.
 # Synced into every owned repo by scripts/sync.sh. Also selectable one-click
 # from the Actions "New workflow" UI. Auth: CLAUDE_CODE_OAUTH_TOKEN (Max sub).
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Canonical pre-commit config — source of truth: tommyroar/.github, synced by scripts/sync.sh.
+# Canonical pre-commit config — source of truth: robogeosociety/.github, synced by scripts/sync.sh.
 # One-time per clone:   uv tool install pre-commit && pre-commit install
 # Ruff version here is kept in lockstep with the ruff run in CI.
 minimum_pre_commit_version: "3.5.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,5 +53,5 @@ PR descriptions follow the **newspaper / information-pyramid** format: one self-
 front page (kicker → headline → dek → masthead → why → what → mermaid flow → screens →
 verification → risk) that reads top-to-bottom on an iPad-mini portrait display (1–2 pages;
 up to 4 for very complex *code* changes). Rebuild from the **full** diff, never append.
-Full rules: <https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md>. CI validates
-the body via the `pr-newspaper` workflow (the reusable gate in `tommyroar/pr-newspaper`).
+Full rules: <https://github.com/robogeosociety/.github/blob/main/PR_FRAMEWORK.md>. CI validates
+the body via the `pr-newspaper` workflow (the reusable gate in `robogeosociety/pr-newspaper`).

--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tommyroar/tallest-tree.git"
+    "url": "git+https://github.com/robogeosociety/tallest-tree.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "bugs": {
-    "url": "https://github.com/tommyroar/tallest-tree/issues"
+    "url": "https://github.com/robogeosociety/tallest-tree/issues"
   },
-  "homepage": "https://github.com/tommyroar/tallest-tree#readme",
+  "homepage": "https://github.com/robogeosociety/tallest-tree#readme",
   "dependencies": {
     "playwright": "^1.58.2"
   },


### PR DESCRIPTION
`fleet` — **ORG RENAME**

Mechanical URL sweep after the tommyroar → robogeosociety org migration — package.json repository/bugs/homepage URLs, the CLAUDE.md PR-framework footer, and the pre-commit + claude.yml source-of-truth comments. Old github.com URLs redirect, so this is canonical cleanup, not a fix; no Pages project URLs in this repo.

## Verification
- `grep -rn tommyroar` — remaining hits: 0
- CI: ci.yml expected green — metadata/comment-only change

## Risk & rollout
- Comment/doc/URL-only (no logic change); redirects cover the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
